### PR TITLE
Fix/announcement elk

### DIFF
--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -1,5 +1,6 @@
 import { NestFactory } from '@nestjs/core';
 import { NestExpressApplication } from '@nestjs/platform-express';
+import { ValidationPipe } from '@nestjs/common';
 import { AppModule } from './app.module';
 import * as cookieParser from 'cookie-parser';
 import * as path from 'path';
@@ -13,6 +14,18 @@ async function bootstrap() {
 
   // Winston 로거를 NestJS 글로벌 로거로 설정
   app.useLogger(app.get(WINSTON_MODULE_NEST_PROVIDER));
+
+  // 글로벌 ValidationPipe 설정 (DTO 자동 검증)
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true, // DTO에 없는 속성 자동 제거
+      forbidNonWhitelisted: true, // DTO에 없는 속성이 있으면 에러
+      transform: true, // 타입 자동 변환
+      transformOptions: {
+        enableImplicitConversion: true,
+      },
+    }),
+  );
 
   // Cookie Parser 미들웨어 추가 (HttpOnly 쿠키 파싱)
   app.use(cookieParser());

--- a/web/src/pages/AnnouncementWrite.jsx
+++ b/web/src/pages/AnnouncementWrite.jsx
@@ -181,11 +181,27 @@ function AnnouncementWrite() {
       return;
     }
 
+    // 날짜 유효성 검증 및 ISO 형식으로 변환
+    const dateRegex = /^\d{4}\.\d{2}\.\d{2}$/;
+    if (!dateRegex.test(date)) {
+      alert('올바른 날짜 형식을 입력해주세요. (YYYY.MM.DD)');
+      return;
+    }
+
+    const isoDate = date.replace(/\./g, '-'); // "2020.01.15" -> "2020-01-15"
+    const dateObj = new Date(isoDate);
+    
+    // Invalid Date 체크
+    if (isNaN(dateObj.getTime())) {
+      alert('유효하지 않은 날짜입니다. 올바른 날짜를 입력해주세요.');
+      return;
+    }
+
     const payload = {
       title,
       contents: content,
       summary,
-      publishAt: date,
+      publishAt: isoDate, // ISO 형식으로 전송
     };
 
     try {


### PR DESCRIPTION
## 문제
잘못된 날짜 입력(예: 2000.99.99) 시 서버가 다운되는 현상 발생

## 원인  
- 잘못된 날짜가 Invalid Date 객체로 변환됨
- 직렬화 과정에서 "0NaN-NaN-NaN..." 형태로 로그에 기록
- 반복적인 에러 로그 발생
- Logstash TCP 버퍼 과부하
- 내부 버퍼 누적으로 메모리 사용량 증가
- HTTP 요청 처리 지연 및 서버 다운 가능성

## 해결
- Frontend 검증: 날짜 형식 체크
- DTO 검증: ValidationPipe
- Service 검증: isNaN(date.getTime())
- Logger 개선: Non-blocking socket.write()