### PR TITLE
Fix/views misalignment at announcement

### DIFF
--- a/web/src/pages/AnnouncementArticle.jsx
+++ b/web/src/pages/AnnouncementArticle.jsx
@@ -244,13 +244,13 @@ function AnnouncementArticle() {
 
             {/* Meta: Removed likes/tags, Left aligned content */}
             <div className="article-meta widget-card rounded-lg p-6 mb-8">
-              <div className="flex flex-wrap items-center justify-between text-sm text-gray-300">
-                <div className="flex items-center space-x-6 mb-2 md:mb-0">
+              <div className="flex flex-wrap items-center justify-between gap-y-2 text-sm text-gray-300">
+                <div className="flex items-center gap-6">
                   <div className="flex items-center space-x-2">
                     <i className="fas fa-user text-blue-400"></i>
                     <span>작성자: {article.author}</span>
                   </div>
-                  <div className="flex items-center space-x-2">
+                  <div className="flex items-center">
                     <i className="fas fa-calendar text-purple-400"></i>
                     <span>
                       {new Date(article.date).toLocaleDateString('ko-KR', {


### PR DESCRIPTION
Suggestion of the issue #60 

Changes
- Removed asymmetric margin (mb-2 md:mb-0).
- Added flex-wrap and gap-y-2 to ensure proper wrapping on smaller screens.
- Ensured consistent vertical centering using items-center.

Tested on FireFox
Before
<img width="488" height="348" alt="스크린샷 2026-02-15 14 48 06" src="https://github.com/user-attachments/assets/5f39f9b6-52be-4479-9085-9b97e45c3b87" />
After
<img width="482" height="345" alt="스크린샷 2026-02-15 14 47 19" src="https://github.com/user-attachments/assets/4b69ef79-2cac-498a-805e-a1eecb8da585" />
After (Zoom 150%)
<img width="484" height="348" alt="스크린샷 2026-02-15 14 51 47" src="https://github.com/user-attachments/assets/8b802203-ac55-4720-b7b9-bc17d44a89a3" />
