### PR TITLE
Feature/add member exposure field

### DIFF
--- a/api/src/members/entities/user.entity.ts
+++ b/api/src/members/entities/user.entity.ts
@@ -100,6 +100,9 @@ export class User {
   @Column({ type: 'boolean', default: false })
   is_public_portfolio_link: boolean;
 
+  @Column({ type: 'boolean', default: false })
+  is_public_current_company: boolean;
+
   @CreateDateColumn()
   created_at: Date;
 

--- a/api/src/members/members.service.ts
+++ b/api/src/members/members.service.ts
@@ -43,6 +43,7 @@ export class MembersService {
       ...(user.is_public_tech_stack && { tech_stack: user.tech_stack }),
       ...(user.is_public_github_username && { github_username: user.github_username }),
       ...(user.is_public_portfolio_link && { portfolio_link: user.portfolio_link }),
+      ...(user.is_public_current_company && { current_company: user.current_company }),
     }));
   }
 

--- a/api/src/migrations/1771146255896-AddIsPublicCurrentCompanyToUser.ts
+++ b/api/src/migrations/1771146255896-AddIsPublicCurrentCompanyToUser.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddIsPublicCurrentCompanyToUser1771146255896 implements MigrationInterface {
+    name = 'AddIsPublicCurrentCompanyToUser1771146255896'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "user" ADD "is_public_current_company" boolean NOT NULL DEFAULT false`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "user" DROP COLUMN "is_public_current_company"`);
+    }
+}

--- a/api/src/mypage/privacy/dto/update-privacy.dto.ts
+++ b/api/src/mypage/privacy/dto/update-privacy.dto.ts
@@ -16,4 +16,8 @@ export class UpdatePrivacyDto {
   @IsOptional()
   @IsBoolean()
   is_public_portfolio_link?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  is_public_current_company?: boolean;
 }

--- a/api/src/mypage/privacy/privacy.service.ts
+++ b/api/src/mypage/privacy/privacy.service.ts
@@ -9,7 +9,7 @@ export class PrivacyService {
   constructor(
     @InjectRepository(User)
     private readonly userRepository: Repository<User>,
-  ) {}
+  ) { }
 
 
   async getPrivacySettings(userId: string) {
@@ -20,6 +20,7 @@ export class PrivacyService {
         is_public_tech_stack: true,
         is_public_github_username: true,
         is_public_portfolio_link: true,
+        is_public_current_company: true,
       },
     });
 


### PR DESCRIPTION
✨ **Changes**

**1. User Entity**

- is_public_current_company boolean 필드 추가 (기본값: false)

**2. Privacy API**
- DTO: UpdatePrivacyDto에 is_public_current_company 필드 추가
- Service: 프라이버시 설정 조회 시 is_public_current_company 포함

**3. Members API**
- 멤버스 페이지에서 is_public_current_company 설정에 따라 current_company 정보 조건부 노출

**4. Database Migration**
- 1771146255896-AddIsPublicCurrentCompanyToUser.ts 마이그레이션 파일 생성